### PR TITLE
Repository updates for github workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,60 @@
+
+<!-- 
+Thank you for contributing to the PRBEM community by
+taking the time to report an IRBEM issue. Please
+describe the issue in detail, and for bug reports
+fill in the fields below.
+
+You can delete the sections that don't apply to your
+issue. For example, if a feature is inadequately
+described, simply delete all sections below and 
+describe how the documentation is lacking. If you
+think you've found a bug that proudces unwanted or
+incorrect behavior then delete the "Error Message"
+section and include a description of what the code
+along with a description of what you think it should
+do. For new feature requests, please describe the 
+feature and at least one possible use case (none of 
+the sections below would be required in that case).
+
+You can view the final output by clicking the preview
+button above.
+-->
+
+My issue is ...
+
+### Minimal example to reproduce issue:
+<!-- 
+If you place your code between the triple backticks below, 
+it will be marked as a code block automatically.
+If possible, please provide a minimal example that succinctly
+illustrate the issue.
+-->
+
+
+```
+Sample code to reproduce the problem
+```
+
+### Error message:
+<!-- If any, paste the *full* error message inside a code block
+as above
+-->
+
+```
+[paste error here]
+```
+
+### OS, IRBEM version, and compiler version information:
+<!-- E.g.,
+`lsb_release -a` to get OS information
+`git rev-parse --short HEAD` to get the short hash of the latest commit
+in your local git repository
+`gfortran --version` to get the version of gfortran
+-->
+
+
+### Source of IRBEM library
+<!-- If you're not using the git repository, please provide as much
+information as possible about where you got IRBEM, when, etc.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Pull Request Checklist
+New code is easier to review, integrate and maintain if it's
+clear, commented, and consistent with the style of the rest
+of the IRBEM code.
+Please try to follow as much of this checklist as you can for
+your PR. If you can't hit everything, or don't know how to,
+then submit the PR and the rest can be discussed during review.
+Some additional suggestions are given below.
+
+Please also see our Code of Conduct so that the PRBEM community
+remains welcoming and inclusive.
+
+Go ahead and replace the text above (and this line!) with your
+pull request description.
+
+- [ ] Pull request has descriptive title
+- [ ] Pull request gives overview of changes
+- [ ] New code has inline comments where necessary
+- [ ] Appropriate documentation has been written
+- [ ] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
+
+<!--
+Thank you so much for your pull request (PR)!  The PRBEM community appreciates your
+help and feedback.  To help us review your contribution, please
+consider the following points:
+
+- Do not create the PR out of master, but out of a separate branch. See `WORKFLOW.md`.
+
+- The PR title should summarize the changes, for example "Fix root finding in field line trace",
+  or "Updated IGRF coefficients for 2025". Avoid non-descriptive titles such as "Bug fix" or
+  "Updates".
+
+- The PR summary should provide at least 1-2 sentences describing the pull request
+  in detail (Why is this change required?  What problem does it solve?) and
+  link to any relevant issues. If the PR resolves an issue, please write this in the summary
+  so that github will automatically close the issue. E.g. "This PR closes #1".
+
+- Please also try to describe what testing has been done to unsure the correctness and robustness
+  of the updates.
+
+We understand that working with PRs can be tricky, even for seasoned contributors.
+Please let us know if reviews are unclear or our recommendations seem like excessive work.
+If you would like help in addressing a reviewer's comments, or if your PR hasn't been
+reviewed in a reasonable timeframe please just comment again.
+-->

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,19 @@
+For contributors unfamiliar with working on shared github repositories,
+the _safe_ workflow is:
+
+- Fork the repository (repo), clone _your fork_ to local machine
+- Working on the repo? New branch for a new feature:
+  - `git branch mynewbranchname`
+  - `git checkout mynewbranchname`
+  - Do work, commit work, then push work with `git push -u origin mynewbranchname`
+- Head to github and send a pull request. It should even have noticed that you pushed a new branch and prompt you.
+- When your PR is merged, update your master from the upstream
+  - Make sure you have the upstream (the PRBEM/IRBEM version) added as a remote (see https://help.github.com/en/articles/configuring-a-remote-for-a-fork)
+  - Make sure you are on _your_ master branch `git checkout master`
+  - Update with `git pull --rebase upstream master`
+
+Why not work from your master branch?
+Well, depending on how pull requests and commits get merged with the upstream "main"
+branch, e.g., merge commit, rebase, squash, ... and how you update (pull, pull with rebase)
+you can end up with either extra commits or conflicting commits. The above workflow avoids
+those issues and keeps updates organized, at the cost of a little bit of extra work.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,86 @@
+# IRBEM Code of Conduct
+
+The scientific community that IRBEM serves is made up of people from around
+the globe with a diverse set of skills, personalities, and experiences. These
+differences are vital to the success and growth of our community. When working
+with, or representing, the IRBEM and PRBEM community we encourage you to
+follow this code of conduct.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting any member of the project team.
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+Translations in a wide range of languages are available from the
+[Contributor Covenant translations][translations] page.
+
+[homepage]: https://www.contributor-covenant.org
+[translations]: https://www.contributor-covenant.org/translations
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+


### PR DESCRIPTION
This pull request adds a few things to make life on github a little easier for contributors and maintainers alike.

I've added:
- A draft code of conduct, which is strongly encouraged across the open-source world.
- A markdown file with basic instructions on maintaining a clean workflow when using forks in git.
- A `.github` directory where the magic markdown goes for:
  - A template that auto-populates new issues to give hints on how to write a helpful issue/bug report.
  - A template that auto-populates new pull requests to ask the requestor for details that will help maintainers with reviewing and merging the PR.

Some suggestions for merging this and future PRs:
- I'd suggest that the `main` branch on this repo is protected, so that all updates come through pull requests. I believe the permission for that only belongs to repo owners.
- Similarly, I'd suggest having someone who _isn't_ the code author merge the pull request. That'll mean making sure an adequate number of developers have permissions to merge.
- Finally, unless there's already a plan on the PRBEM side for the merge strategy I'd suggest setting the repository to only allow merge via rebase.  This provides a linear history. The downside is that when multiple PRs are waiting to be merged they can get out of sync - so occasionally the PR will have to be updated (by updating main, rebasing the PR branch against main, and then force-pushing the PR branch). On other projects I've not found this to cause any problems... especially since maintainers can do this for the PR submitter if required.