### PR TITLE
Fix coordinate transform initialization on call of gsm2sm1

### DIFF
--- a/source/onera_desp_lib.f
+++ b/source/onera_desp_lib.f
@@ -2156,6 +2156,11 @@ c
       REAL*8    secs,psi,dyear
       REAL*8    xGSM(3),xSM(3)
 
+        dyear=iyr+0.5d0
+        psi=0.d0
+        call initize ! sets rad, pi used by various routines
+
+        CALL INIT_DTD(dyear)
         CALL INIT_GSM(iyr,idoy,secs,psi)
         CALL GSM_SM(xGSM,xSM)
         end


### PR DESCRIPTION
Calling a coordinate transformation from GSM to SM, prior to any other transformations returns bad values.
This came up in spacepy/spacepy#534

I was able to reproduce the error by calling the IRBEM functions directly from the `.so` using Python's ctypes interface. I was also able to reproduce the error using the `coords_transform` method in IRBEM's own Python tools.
(see the spacepy issue for the direct calls to the compiled library, but can also be done using the IRBEM module as follows):
```
import datetime as dt
import IRBEM
coords = IRBEM.Coords(IRBEMdir='~/github/IRBEM/', IRBEMname='onera_desp_lib_linux_x86_64.so')
coords.coords_transform(dt.datetime(2002, 2, 2, 12), [1., 2., 4.], 2, 4)
```
the return is then
```
array([[nan, nan, nan]])
```

`gsm2sm1` was missing the calls to `initize` and `init_DTD` that are present in the other coordinate conversion routines. These _used to be present_, and were removed in d0af792b3643a82bf0b01a3013ad1034c7d02e72
during a raft of formatting updates.

This PR adds the initialization calls back.
Command line testing as above now yields a non-NaN answer:
```
array([[1.92990225, 2.        , 3.64355284]])
```

To verify correctness, we can compare with the high-accuracy Python-based SpacePy routines (in spacepy/spacepy#296 ; note these have almost complete test coverage including comparison with LANLGeoMag and IRBEM):
```
import spacepy.coordinates as spc
import spacepy.time as spt
cc = spc.Coords([1,2,4], 'GSM', 'car', use_irbem=False)
cc.ticks = spt.Ticktock('2002-02-02T12:00:00')
cc.convert('SM', 'car')
```
and the result is
```
Coords( [[1.9292696248256644, 2.0, 3.643887857045691]] , 'SM', 'car')
```

## Pull Request Checklist
- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Appropriate documentation has been written
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
