### PR TITLE
Fix and update coordinate transformations

### DIFF
--- a/docs/frames/frames.html
+++ b/docs/frames/frames.html
@@ -173,32 +173,72 @@
         system is provided in</font> 
         <br />
     </p>
-    <div style="MARGIN-LEFT: 40px"><font face="ARIAL, HELVETICA">0: GDZ (alti, lati, East
-        longi - km,deg.,deg)</font> 
+    <div style="MARGIN-LEFT: 40px">
+        <font face="ARIAL, HELVETICA">
+        <b>0: GDZ</b> (geodetic; altitude, latitude, East longitude) - km, deg., deg.
+        <br />Defined using a reference ellipsoid. Geodetic longitude is identical to GEO longitude. Both the altitude
+    and latitude depend on the ellipsoid used. IRBEM uses the WGS84 reference ellipsoid.
         <br />
-        <font face="ARIAL, HELVETICA">1: GEO (cartesian) - Re</font> 
+        <b>1: GEO</b> (geocentric geographic; Cartesian) - Re 
+        <br />Earth-Centered and Earth-Fixed. X lies in the Earth's equatorial plane (zero latitude) and intersects the Prime
+        Meridian (zero longitude; Greenwich, UK). Z points to True North (roughly aligned with the instantaneous rotation axis).
         <br />
-        <font face="ARIAL, HELVETICA">2: GSM (cartesian) - Re</font> 
+        <b>2: GSM</b> (geocentric solar magnetospheric; Cartesian) - Re
+        <br />X points sunward from Earth's center. The X-Z plane is defined to contain Earth's dipole axis (positive North).
         <br />
-        <font face="ARIAL, HELVETICA">3: GSE (cartesian) - Re</font> 
+        <b>3: GSE</b> (geocentric solar ecliptic; Cartesian) - Re
+        <br />X points sunward from Earth's center. Y lies in the ecliptic plane of date, pointing in the anti-orbit direction. Z is parallel
+    to the ecliptic pole of date.
         <br />
-        <font face="ARIAL, HELVETICA">4: SM (cartesian) - Re</font> 
+        <b>4: SM</b> (solar magnetic; Cartesian) - Re
+        <br />Z is aligned with the centered dipole axis of date (positive North), and Y is perpendicular to both the Sun-Earth line and
+    the dipole axis. X is therefore is not aligned with the Sun-Earth line and SM is a rotation about Y from GSM.
         <br />
-        <font face="ARIAL, HELVETICA">5: GEI (cartesian) - Re</font> 
+        <b>5: GEI</b> (geocentric equatorial inertial, of Date; Cartesian) - Re
+        <br />X points from Earth toward the equinox of date (first point of Aries; position of the Sun at the vernal equinox). Z is parallel to the instantaneous rotation axis of the Earth.
         <br />
-        <font face="ARIAL, HELVETICA">6: MAG (cartesian) - Re</font> 
+        <b>6: MAG</b> (geomagnetic; Cartesian) - Re
+        <br />Z is parallel to Earth's centered dipole axis (positive North). Y is the intersection between Earth's equator and the geographic meridian 90 degrees east of the meridan containing the dipole axis.
         <br />
-        <font face="ARIAL, HELVETICA">7: SPH (geo in spherical) - (radial distance, lati,
-        East longi - Re, deg., deg.)<br />
-        </font><font face="ARIAL, HELVETICA">8: RLL&nbsp; (radial distance, lati, East longi
-        - Re, deg., deg. - prefered to 7)</font> 
+        <b>7: SPH</b> (GEO in spherical; radial distance, latitude, East longitude) - Re, deg., deg.
+        <br />Geoecentric geographic coordinates (GEO system) expressed in spherical instead of Cartesian.
         <br />
+        <b>8: RLL</b> (geodetic; radial distance, geodetic latitude, East longitude) - Re, deg., deg.
+        <br /> A re-expression of geodetic (GDZ) coordinates using radial distance instead of altitude above the reference ellipsoid. Note that the latitude is still geodetic latitude and is therefore not interchangeable with SPH.
+        <br />
+        <b>9: HEE</b> (Heliocentric Earth ecliptic; Cartesian) - Re
+        <br />Origin is solar center; X points towards the Earth, and Z is perpendicular to the plane of Earth's orbit (positive North). This system is fixed with respect to the Earth-Sun line.
+        <br />
+        <b>10: HAE</b> (Heliocentric Aries ecliptic; Cartesian) - Re
+        <br />Origin is solar center. Z is perpendicular to the plane of Earth's orbit (positive North) and X points towards the equinox of date (first point of Aries).
+        <br />
+        <b>11: HEEQ</b> (Heliocentric Earth equatorial; Cartesian) - Re
+        <br />Origin is solar center. Z is parallel to the Sun's rotation axis (positive North) and X points towards the intersection of the solar equator and solar central meridian as seen from Earth.
+        <br />
+        <b>12: TOD</b> (True of Date; same as GEI) - Re
+        <br />This is the same as IRBEM's GEI and both are included for legacy support. TOD uses the "true" (not mean) equator of date and equinox of date to define the coordinate system.
+        <br />
+        <b>13: J2000</b> (GEI at J2000; Cartesian) - Re
+        <br />A key geocentric inertial frame. X is aligned with the mean equinox at J2000; Z is parallel to the mean rotation axis of the Earth at J2000 (that is, perpendicular to the mean equator of J2000).
+        The mean equinox of date and mean equator of date (at any epoch) correct only for precession, and not nutation.
+        <br />
+        <b>14: TEME</b> (True Equator Mean Equinox; Cartesian) - Re
+        <br />
+        <i>Notes:
+            <br>- Four geocentric equatorial inertial systems are in widespread use. These are J2000, MOD (Mean of Date), TOD, and TEME.
+            J2000 defines the axes using the equinox and pole at the J2000 epoch. Correcting for precession transforms to MOD (which is identical to J2000 at 2000-01-01T11:58:55.816 UTC), and then correcting for nutation tansforms to TOD (GEI).
+            IRBEM defines the geophysical systems (e.g., [GSE, GSM, SM]) relative to TOD, although some missions define these coordinate systems relative to a different inertial reference system
+            (usually MOD).
+            <br>- For details of the approximations used by IRBEM's coordinate transformations, including the equation for estimating the Sun vector, see <a href="http://jsoc.stanford.edu/~jsoc/keywords/Chris_Russel/Geophysical%20Coordinate%20Transformations.htm">Russell (1971)</a> and 
+            <a href="https://doi.org/10.1016/0032-0633(92)90012-D">Hapgood (1992)</a>
+            <br>- TEME is the inertial system used by the SGP4 orbit propagator.</i>
+        </font>
     </div>
     <p>
     </p>
     <p>
         <font face="ARIAL, HELVETICA"><b>iyear</b>, <b>iyr</b> or <b>iyearsat</b>: array(NTIME_MAX) of long integer year when
-        measurements are given. /font> 
+        measurements are given. </font>
     <br>
         <font face="ARIAL, HELVETICA"><b>idoy:</b> array(NTIME_MAX) of long integer doy when
         measurements are given</font> 
@@ -1433,9 +1473,8 @@
     </h2>
     <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">DESCRIPTION:</font></font> 
     </h3>
-    <font face="ARIAL, HELVETICA">Generic coordinates transformation from one Earth&nbsp;or
-    Heliospheric coordinate system to another&nbsp;</font>&nbsp;<font face="Arial">Earth&nbsp;or
-    Heliospheric coordinates system. Handle up to GET_IRBEM_NTIME_MAX() times at once.</font> 
+    <font face="ARIAL, HELVETICA">Generic coordinates transformation from one geophysical or
+    heliospheric coordinate system to another. Handles up to GET_IRBEM_NTIME_MAX() times at once.</font>
     <br />
     &nbsp; 
     <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">INPUTS:</font></font> 
@@ -1444,8 +1483,8 @@
 
       <b>ntime, sysaxesIN, sysaxesOUT, iyr, idoy, secs, xIN</b> <p>
 
-      see <a href=#COMMON_ARGUMENTS>Common Argument
-      Definitions</a>
+      For definitions of the coordinate systems, and notes on transformations, see <a href=#COMMON_ARGUMENTS>Common Argument
+      Definitions</a>.
 	  <p>
 	<font face="ARIAL, HELVETICA"><b>sysaxesIN:</b> long integer&nbsp;indicating input
     coordinates system</font>&nbsp;<br />
@@ -1540,6 +1579,11 @@
                         J2000 (13) 
                     </p>
                 </td>
+                <td bgcolor="#c0c0ff" rowspan="2">
+                    <p align="center">
+                        TEME (14)
+                    </p>
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80">
@@ -1554,6 +1598,8 @@
                     </p>
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1616,6 +1662,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1628,6 +1676,8 @@
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1686,6 +1736,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1702,6 +1754,8 @@
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1756,6 +1810,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1776,6 +1832,8 @@
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1826,6 +1884,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1850,6 +1910,8 @@
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1896,6 +1958,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
             <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1924,6 +1988,8 @@
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">
                 </td>
@@ -1963,6 +2029,8 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
                         <tr>
                 <td bgcolor="#ffff80" colspan="2">
@@ -1995,10 +2063,48 @@
                 </td>
                 <td bgcolor="lime">
                 </td>
+                <td bgcolor="lime">
+                </td>
             </tr>
                         <tr>
                 <td bgcolor="#ffff80" colspan="2">
                     J2000 (13)</td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="lime">
+                </td>
+                <td bgcolor="#ff8000">
+                </td>
+                <td bgcolor="lime">
+                </td>
+            </tr>
+            <tr>
+                <td bgcolor="#ffff80" colspan="2">
+                    TEME (14)</td>
+                <td bgcolor="lime">
+                </td>
                 <td bgcolor="lime">
                 </td>
                 <td bgcolor="lime">

--- a/docs/frames/introduction.html
+++ b/docs/frames/introduction.html
@@ -21,57 +21,58 @@
 </head>
 <body>
     <!-- Insert content here -->
-    <div style="TEXT-ALIGN: center"><big><big><font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big>Version
-        4.4.0 - August 2012</big></big></font></font></font> 
+    <div style="TEXT-ALIGN: center"><big><big><font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2">
+        <big><big>See source repository for version and release details</big></big></font></font></font> 
         <br />
-        <font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big><span style="TEXT-DECORATION: underline">Authors:</span> D.
-        Boscher, S. Bourdarie - ONERA-DESP, Toulouse France (Fortran code and IDL wrappers)</big></big></font></font></font></big></big> 
+        <font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big><span style="TEXT-DECORATION: underline">Authors and contributors</span><br> D.
+        Boscher, S. Bourdarie - ONERA-DESP, Toulouse France
         <br />
-        <font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big><span style="TEXT-DECORATION: underline"></span>T.
-        Guild - The Aerospace Corporation - USA&nbsp; (Fortran code)</big></big></font></font></font> 
+        T. Paul O'Brien, T. Guild - The Aerospace Corporation - USA
+        <br />and<br />
+        D. Heynderickx, S. Morley, A. Kellerman, C. Roth, H. Evans, A. Brunet, M. Shumko, C. Lemon, S. Claudepierre, T. Nilsson
+        <br />and the IRBEM contributor community
+        </big></big></font></font></font> 
     </div>
-    <div style="TEXT-ALIGN: center"><big><big><font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big>Paul
-        O'Brien - The Aerospace Corporation - USA&nbsp; (MATLAB wrappers)<br />Daniel
-        Heynderickx - DH Consultancy BVBA - Belgium&nbsp; (preparation of this release)</big></big></font></font></font></big></big><big><big>&nbsp;<br />
+    <div style="TEXT-ALIGN: center"><big><big>&nbsp;<br />
         <font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big>For
-        any questions or to report bugs please contact</big></big></font></font></font> 
+        any questions or to report bugs please visit <a href="https://github.com/PRBEM/IRBEM/issues">the issue tracker</a> at 
+        <a href="https://github.com/PRBEM/IRBEM">the source repository on GitHub</a>
+        </big></big></font></font></font> 
         <br />
-        <font face="ARIAL, HELVETICA"><font color="#0000ff"><font size="-2"><big><big><a href="mailto:Sebastien.Bourdarie@onecert.fr">Dr.
-        Sebastien Bourdarie</a> or <a href="mailto:Daniel.Boscher@onecert.fr">Dr. Daniel Boscher</a>&nbsp;or <a href="mailto:Paul.OBRIEN@aero.org">Dr.
-        Paul O'Brien</a> </big></big></font></font></font></big></big>
+        
+        </font></big></big>
     </div>
     <BR>
     <BR>
     <p>
-    <font face="ARIAL, HELVETICA"><font size=+1>The International Radiation Belt Environment Modeling (IRBEM) library is freely distributed under the
-    umbrella of the PRBEM COSPAR panel (<a href="http://cosparhq.cnes.fr/Scistr/Scistr.htm#PRBEM">
-    http://cosparhq.cnes.fr/Scistr/Scistr.htm#PRBEM</a>).<BR>
+    <font face="ARIAL, HELVETICA">The International Radiation Belt Environment Modeling (IRBEM) library is freely distributed under the
+    umbrella of <a href="http://cosparhq.cnes.fr/Scistr/Scistr.htm">COSPAR</a>'s <a href="https://prbem.github.io/">PRBEM (Panel on Radiation Belt Modeling</a>.<br>
     In 2003 ONERA-DESP (space environment department) decided to put together a set of source codes into a 
     library dedicated to radiation belt modeling. The toolkit was then called ONERA-DESP-LIB. Because the project has grown
-    along time, and because its development is nowadays more like an international collaborative effort, it has been decided in 2008,
-    after COSPAR 2008 Montreal assembly, to move the library name to IRBEM-LIB (which refers to COSPAR PRBEM panel) and to
-    distribute it under COSPAR PRBEM umbrella (a neutral body).</font></font>
+    with time, and because its development is now an international collaborative effort, it was decided in 2008,
+    after COSPAR 2008 Montreal assembly, to change the library name to IRBEM-LIB (which refers to COSPAR PRBEM panel) and to
+    distribute it under the COSPAR PRBEM umbrella (a neutral body).</font>
     </p>
     <p>
         <br />
-        <font face="ARIAL, HELVETICA"><font size=+1>The following document describes how to
+        <font face="ARIAL, HELVETICA">The following document describes how to
         use the IRBEM fortran library (formerly the ONERA-DESP library) to compute magnetic coordinates and drift shells
         using various external magnetic field models.&nbsp; Further routines are provided
-        for&nbsp; various coordinate and time format transformations.</font></font> 
+        for&nbsp; various coordinate and time format transformations.</font>
     </p>
     <p>
-        <font face="ARIAL, HELVETICA"><font size=+1>The library can be called from FORTRAN
+        <font face="ARIAL, HELVETICA">The library can be called from FORTRAN
         or C code and from IDL&nbsp;or MATLAB code. For IDL and MATLAB wrappers are provided
-        in the distribution package.</font></font>&nbsp; 
+        in the distribution package.</font>&nbsp; 
     </p>
     <p>
-        <font face="ARIAL, HELVETICA"><font size=+1>The package includes a Makefile 
+        <font face="ARIAL, HELVETICA">The package includes a Makefile 
         to built the library on various platform, install
-        it&nbsp;and test it (See section installation for more details).&nbsp;</font></font> 
+        it&nbsp;and test it (See section installation for more details).&nbsp;</font>
     </p>
     <p>
-        <font face="ARIAL, HELVETICA"><font size=+1>Two libraries are created, one for access
-        from IDL or MATLAB and one for access from fortran or some other language.</font></font> 
+        <font face="ARIAL, HELVETICA">Two libraries are created, one for access
+        from IDL or MATLAB and one for access from fortran or some other language.</font>
         <br />
     </p>
     <p>
@@ -105,44 +106,38 @@
     or usefulness of any information, apparatus, product, or process disclosed in documents and software available 
     from the IRBEM library or developed as a result of the use of information or software made available from the library. <BR>
     <BR>
-     If you want to fully refer to this
-        library in publications or reports, use the following: "D. Boscher<sup>1</sup>, S.
-        Bourdarie<sup>1</sup>, P. O'Brien<sup>2</sup>, T. Guild<sup>2</sup>,(<sup>1</sup> ONERA-DESP,
-        Toulouse France; <sup>2</sup> Aerospace Corporation, Washington DC, USA),&nbsp;IRBEM
-        library V4.3, 2004-2008".<br />
+    To refer to this library in publications or reports, please provide the URL of the source repository (https://github.com/PRBEM/IRBEM)
+    and see the project README for additional, up-to-date citation details.
         </font></span>
     </p>
     <p>
-        <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA"><span style="TEXT-DECORATION: underline">Acknowledgments:</span> The
-        authors whish to thanks:<br />
+        <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA"><span style="TEXT-DECORATION: underline">Acknowledgments:</span>
         </font></span>
     </p>
     <div style="MARGIN-LEFT: 40px">
+        <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">
+        <font size="-1">The authors wish to thank:
         <ul>
             <li>
-                <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">K. Pfitzer, N. Tsyganenko,
+                K. Pfitzer, N. Tsyganenko,
                 I. Alexeev and their co-authors for providing us magnetic field model source codes
-                and for good discussions on how to use their model correctly.&nbsp;</font></span><span style="FONT-STYLE: italic"></span> 
+                and for good discussions on how to use their models correctly.
             </li>
             <li>
-                <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">R. Friedel (LANL),
-                Y. Dotan and M. Redding (Aerospace corporation) for good discussions, advices and
-                bug reports which are always very helpfull when one attemps to develop such a tool.</font></span> 
+                R. Friedel (LANL), Y. Dotan and M. Redding (Aerospace corporation) for good discussions, advice and
+                bug reports which are always very helpfull when one attemps to develop such a tool.
             </li>
             <li>
-                <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">D. Bilitza for his
-                help regarding the use of IGRF magnetic field model and MSIS models.</font></span> 
+                D. Bilitza for his help regarding the use of IGRF magnetic field model and MSIS models.
             </li>
             <li>
                 <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">D. Brautigam for providing
                 us CRRES models.</font></span> 
             </li>
             <li>
-                <span style="FONT-STYLE: italic"><font face="ARIAL, HELVETICA">D. Vallado for providing&nbsp;free
-                of use&nbsp;source code for orbit propagator (SGP4).<br />
-                </font></span>
+                D. Vallado for providing <u>free of use</u> source code for orbit propagator (SGP4).<br />
             </li>
-        </ul>
+        </ul></font></font></span>
     </div>
     <p>
     </p>

--- a/source/CoordTrans.f
+++ b/source/CoordTrans.f
@@ -1204,7 +1204,7 @@ c input=GDZ
             call gdz_geo(xIN(2),xIN(3),xIN(1),xTMP(1),xTMP(2),xTMP(3))
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call gdz_geo(xIN(2),xIN(3),xIN(1),xTMP(1),xTMP(2),xTMP(3))
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1259,21 +1259,9 @@ c input=GDZ
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call gdz_geo(xIN(2),xIN(3),xIN(1),xTMP(1),xTMP(2),xTMP(3))
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call gdz_geo(xIN(2),xIN(3),xIN(1),xTMP(1),xTMP(2),xTMP(3))
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1295,7 +1283,7 @@ c input=GEO
          if (sysaxesOUT.EQ.4) then  !SM
             call geo2sm1(iyr,idoy,secs,xIN,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call geo2gei1(iyr,idoy,secs,xIN,xOUT)
          endif
          if (sysaxesOUT.EQ.6) then  !MAG
@@ -1334,19 +1322,8 @@ c input=GEO
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call geo2gei1(iyr,idoy,secs,xIN,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call geo2gei1(iyr,idoy,secs,xIN,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1371,7 +1348,7 @@ c input=GSM
          if (sysaxesOUT.EQ.4) then  !SM
             call gsm2sm1(iyr,idoy,secs,xIN,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call gsm2geo1(iyr,idoy,secs,psi,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1430,21 +1407,9 @@ c input=GSM
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call gsm2geo1(iyr,idoy,secs,psi,xIN,xTMP)
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call gsm2geo1(iyr,idoy,secs,psi,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1470,7 +1435,7 @@ c input=GSE
             call gse2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call gse2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1508,21 +1473,9 @@ c input=GSE
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call gse2geo1(iyr,idoy,secs,xIN,xTMP)
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call gse2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1547,7 +1500,7 @@ c input=SM
             call sm2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2gse1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call sm2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1606,29 +1559,17 @@ c input=SM
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call sm2geo1(iyr,idoy,secs,xIN,xTMP)
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call sm2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             CALL ECITOD_2_ECIJ2000(iyr,idoy,secs,xTMP,xOUT)
          endif
       endif
-c input=GEI
-      if (sysaxesIN.EQ.5) then
+c input=GEI (which is also ECI ToD)
+      if ((sysaxesIN.EQ.5).or.(sysaxesIN.EQ.12)) then
          if (sysaxesOUT.EQ.0) then  !GDZ
             call gei2geo1(iyr,idoy,secs,xIN,xTMP)
             call geo_gdz(xTMP(1),xTMP(2),xTMP(3),
@@ -1705,11 +1646,12 @@ c input=GEI
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
          if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
+            do i=1,3
+               xOUT(i)=xIN(i)
+            enddo
          endif
          if (sysaxesOUT.EQ.13) then  !J2000
-            call teme2ecitod(iyr,idoy,secs,xIN,xTMP)
-            CALL ECITOD_2_ECIJ2000(iyr,idoy,secs,xTMP,xOUT)
+            CALL ECITOD_2_ECIJ2000(iyr,idoy,secs,xIN,xOUT)
          endif
       endif
 c
@@ -1736,7 +1678,7 @@ c input=MAG
               call mag2geo1(iyr,xIN,xTMP)
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
               call mag2geo1(iyr,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1791,21 +1733,9 @@ c input=MAG
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-          call mag2geo1(iyr,xIN,xTMP)
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
-          call mag2geo1(iyr,xIN,xTMP)
+            call mag2geo1(iyr,xIN,xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1835,7 +1765,7 @@ c input=SPH
             call SPH_CAR(xIN(1),xIN(2),xIN(3),xTMP)
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call SPH_CAR(xIN(1),xIN(2),xIN(3),xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
          endif
@@ -1890,21 +1820,9 @@ c input=SPH
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call SPH_CAR(xIN(1),xIN(2),xIN(3),xTMP)
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call SPH_CAR(xIN(1),xIN(2),xIN(3),xTMP)
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -1939,7 +1857,7 @@ c input=RLL
             call gdz_geo(xIN(2),xIN(3),alti,xTMP(1),xTMP(2),xTMP(3))
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
               call RLL_GDZ(xIN(1),xIN(2),xIN(3),alti)
             call gdz_geo(xIN(2),xIN(3),alti,xTMP(1),xTMP(2),xTMP(3))
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
@@ -1993,23 +1911,10 @@ c input=RLL
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-          call RLL_GDZ(xIN(1),xIN(2),xIN(3),alti)
-            call gdz_geo(xIN(2),xIN(3),alti,xTMP(1),xTMP(2),xTMP(3))
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
           call RLL_GDZ(xIN(1),xIN(2),xIN(3),alti)
             call gdz_geo(xIN(2),xIN(3),alti,xTMP(1),xTMP(2),xTMP(3))
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -2056,7 +1961,7 @@ c input=HEE
             enddo
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call hee2gse1(iyr,idoy,secs,xIN,xTMP)
             call gse2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
@@ -2100,18 +2005,6 @@ c input=HEE
             call hee2hae1(iyr,idoy,secs,xIN,xTMP)
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call hee2gse1(iyr,idoy,secs,xIN,xTMP)
-            call gse2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call hee2gse1(iyr,idoy,secs,xIN,xTMP)
             call gse2geo1(iyr,idoy,secs,xTMP,xOUT)
@@ -2119,10 +2012,6 @@ c input=HEE
                xTMP(i)=xOUT(i)
             enddo
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -2189,7 +2078,7 @@ c input=HAE
             enddo
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call hae2hee1(iyr,idoy,secs,xIN,xTMP)
             call hee2gse1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
@@ -2248,22 +2137,6 @@ c input=HAE
          if (sysaxesOUT.EQ.11) then  !HEEQ
             call hae2heeq1(iyr,idoy,secs,xIN,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call hae2hee1(iyr,idoy,secs,xIN,xTMP)
-            call hee2gse1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call gse2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call hae2hee1(iyr,idoy,secs,xIN,xTMP)
             call hee2gse1(iyr,idoy,secs,xTMP,xOUT)
@@ -2275,10 +2148,6 @@ c input=HAE
                xTMP(i)=xOUT(i)
             enddo
             call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
@@ -2365,7 +2234,7 @@ c input=HEEQ
             enddo
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
             call heeq2hae1(iyr,idoy,secs,xIN,xTMP)
             call hae2hee1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
@@ -2441,26 +2310,6 @@ c input=HEEQ
          if (sysaxesOUT.EQ.10) then  !HAE
             call heeq2hae1(iyr,idoy,secs,xIN,xOUT)
          endif
-         if (sysaxesOUT.EQ.12) then  !ECI ToD
-            call heeq2hae1(iyr,idoy,secs,xIN,xTMP)
-            call hae2hee1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call hee2gse1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call gse2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gei1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-         endif
          if (sysaxesOUT.EQ.13) then  !J2000
             call heeq2hae1(iyr,idoy,secs,xIN,xTMP)
             call hae2hee1(iyr,idoy,secs,xTMP,xOUT)
@@ -2479,149 +2328,14 @@ c input=HEEQ
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
-            call teme2ecitod(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             CALL ECITOD_2_ECIJ2000(iyr,idoy,secs,xTMP,xOUT)
          endif
       endif
 c
-c input=ECI ToD (True of Date)
-      if (sysaxesIN.EQ.12) then
-         if (sysaxesOUT.EQ.0) then  !GDZ
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo_gdz(xTMP(1),xTMP(2),xTMP(3),
-     &                     xOUT(2),xOUT(3),xOUT(1))
-         endif
-         if (sysaxesOUT.EQ.1) then  !GEO
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.2) then  !GSM
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gsm1(iyr,idoy,secs,psi,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.3) then  !GSE
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gse1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.4) then  !SM
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.5) then  !GEI (J2000)
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xOUT)
-         endif
-         if (sysaxesOUT.EQ.6) then  !MAG
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2mag1(iyr,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.7) then  !SPH
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call CAR_SPH(xTMP,xOUT(1),xOUT(2),xOUT(3))
-         endif
-         if (sysaxesOUT.EQ.8) then  !RLL
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo_gdz(xTMP(1),xTMP(2),xTMP(3),
-     &                     xOUT(1),xOUT(2),xOUT(3))
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            xOUT(1)=SQRT(xIN(1)*xIN(1)+xIN(2)*xIN(2)+xIN(3)*xIN(3))
-            xOUT(2)=xTMP(1)
-            xOUT(3)=xTMP(2)
-         endif
-         if (sysaxesOUT.EQ.9) then  !HEE
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gse1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call gse2hee1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.10) then  !HAE
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gse1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call gse2hee1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call hee2hae1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.11) then  !HEEQ
-            call ECITOD2TEME(iyr,idoy,secs,xIN,xTMP)
-            call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call geo2gse1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call gse2hee1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call hee2hae1(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
-            call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.12) then  !ECI TOD
-            CALL ECITOD2TEME(iyr,idoy,secs,xIN,xOUT)
-         ENDIF
-         endif
-
-
 c input=J2000
       if (sysaxesIN.EQ.13) then
          if (sysaxesOUT.EQ.0) then  !GDZ
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2631,18 +2345,10 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.1) then  !GEO
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
          endif
          if (sysaxesOUT.EQ.2) then  !GSM
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2651,10 +2357,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.3) then  !GSE
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2663,26 +2365,17 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.4) then  !SM
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
             enddo
             call geo2sm1(iyr,idoy,secs,xTMP,xOUT)
          endif
-         if (sysaxesOUT.EQ.5) then  !GEI (TEME)
-            call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
+         if ((sysaxesOUT.EQ.5).or.(sysaxesOUT.EQ.12)) then  !GEI (TOD)
+            call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xOUT)
          endif
          if (sysaxesOUT.EQ.6) then  !MAG
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2691,10 +2384,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.7) then  !SPH
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2703,10 +2392,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.8) then  !RLL
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2722,10 +2407,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.9) then  !HEE
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2738,10 +2419,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.10) then  !HAE
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2758,10 +2435,6 @@ c input=J2000
          endif
          if (sysaxesOUT.EQ.11) then  !HEEQ
             call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
-            call ECITOD2TEME(iyr,idoy,secs,xTMP,xOUT)
-            do i=1,3
-               xTMP(i)=xOUT(i)
-            enddo
             call gei2geo1(iyr,idoy,secs,xTMP,xOUT)
             do i=1,3
                xTMP(i)=xOUT(i)
@@ -2779,9 +2452,6 @@ c input=J2000
                xTMP(i)=xOUT(i)
             enddo
             call hae2heeq1(iyr,idoy,secs,xTMP,xOUT)
-         endif
-         if (sysaxesOUT.EQ.12) then  !ECI TOD
-            call ECIJ2000_2_ECITOD(iyr,idoy,secs,xIN,xTMP)
          endif
       endif
 c

--- a/source/Mead_Tsyganenko.f
+++ b/source/Mead_Tsyganenko.f
@@ -36,7 +36,7 @@ C   A VOIR CE QUE CA VAUT... (idee de Daniel)
 
 		lati = (3.1416/2-thetaMAG) * 180./3.1416
 		longi = phiMAG * 180./3.1416
-		CALL SPH2CAR(Bval,lati,longi,BMAG)
+		CALL SPH_CAR(Bval,lati,longi,BMAG)
 		CALL MAG_GEO(BMAG,BGEO)
 
 

--- a/source/init_nouveau.f
+++ b/source/init_nouveau.f
@@ -1534,27 +1534,27 @@ C
       PARAMETER (precision = 1.D-5) ! increase precision to 1E-5
 C
       REAL*8 lati,longi,lat0
-        REAL*8 alti,xx,yy,zz,alt0
-        REAL*8 D,RHO
-        REAL*8 ERA,AQUAD,BQUAD
-        integer*4 i
+      REAL*8 alti,xx,yy,zz,alt0
+      REAL*8 D,RHO
+      REAL*8 ERA,AQUAD,BQUAD
+      integer*4 i
 C
-        COMMON/GENER/ERA,AQUAD,BQUAD
-        REAL*8     pi,rad
-        common /rconst/rad,pi
+      COMMON/GENER/ERA,AQUAD,BQUAD
+      REAL*8     pi,rad
+      common /rconst/rad,pi
 C
-        CALL INITIZE
+      CALL INITIZE
       longi = ATAN2(yy,xx)/rad
       RHO = SQRT(xx*xx+yy*yy)
       lati = ATAN2(zz,RHO)
       D = COS(lati)
-      IF (D.LT.1.D-15)THEN
+      IF (D.LT.1.D-15) THEN  !trap for pole
         lati = lati/rad
-        alti = (zz-1.D0)*SQRT(BQUAD)
+        alti = (abs(zz)-1.D0)*SQRT(BQUAD)
       ELSE
         alti = RHO/D - 1.D0
 C
-      i=0
+        i=0
 10        CONTINUE
         alt0 = alti
         lat0 = lati
@@ -1562,7 +1562,7 @@ C
         lati = ATAN2(zz*(alt0+AQUAD/D/ERA),RHO*(alt0+BQUAD/D/ERA))
         alti = RHO/cos(lati) - AQUAD/D/ERA
         i=i+1
-        if (i .gt. 1000) then
+        if (i .gt. 1000) then  !failed to converge
           alti=0.
           lati=0.
         !write(6,*)'geo2gdz ',i,alti
@@ -1570,7 +1570,7 @@ C
         endif
         IF (ABS(alti - alt0).GT. precision .OR. ABS(lati -
      &     lat0) .GT. precision) GOTO 10 ! keep looping until BOTH are within precision
-          alti = alti*ERA
+        alti = alti*ERA
         lati = lati/rad
         ENDIF
         !write(6,*)'geo2gdz ',i,alti


### PR DESCRIPTION
This PR addresses three main issues:
1. The conversions between the "old" coordinate systems (GEO, GEI, GSM, GDZ, etc.) and the more-recently-added systems (J2000, TOD) incorrectly assumes that GEI is equivalent to TEME. However, IRBEM's GEI is equivalent to TOD. See [this comment](https://github.com/spacepy/spacepy/issues/578#issuecomment-1059644395) for an explanation. Note that this also turned up the problem that GEI->TOD didn't work at all...
2. The GEO to GDZ conversion fails for southern polar coordinates. Closes #29 (but preserves the original algorithm, so still doesn't use an exact method)
3. There's a call to a renamed function in `Mead_Tsyganenko.f`. Closes #31 

The bulk of the changed code sets the equivalence between GEI and TOD in `CoordTrans.f`. This removes the incorrect transforms from GEI to TOD that impacted all of the transforms to both TOD and J2000 (from any system). This also fixes the GEI to TOD conversion as it now just returns the input.

While updating these transforms I added TEME as a supported system as it's useful for anyone using the SGP4 orbit propagator (which outputs in TEME).

The south pole is now explicitly trapped in `GEO_GDZ` with a correction to how the altitude is calculated for the southern pole.

The `SPH2CAR`call in `Mead_Tsyganenko.f` has been replaced with a call to `SPH_CAR`

#### PR Checklist
- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Appropriate documentation has been written
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)