### PR TITLE
Constrain the shared object search in the Python wrapper

### DIFF
--- a/python/IRBEM/IRBEM.py
+++ b/python/IRBEM/IRBEM.py
@@ -1078,12 +1078,12 @@ def _load_shared_object(path=None):
     """
     if path is None:
         if (sys.platform == 'win32') or (sys.platform == 'cygwin'):
-            obj_ext = '*.dll'
+            obj_name = 'libirbem.dll'
             loader = ctypes.WinDLL
         else:
-            obj_ext = '*.so'
+            obj_name = 'libirbem.so'
             loader = ctypes.cdll
-        matched_object_files = list(pathlib.Path(__file__).parents[2].glob(obj_ext))
+        matched_object_files = list(pathlib.Path(__file__).parents[2].rglob(obj_name))
         assert len(matched_object_files) == 1, (
             f'{len(matched_object_files)} .so or .dll shared object files found in '
             f'{pathlib.Path(__file__).parents[2]} folder: {matched_object_files}.'


### PR DESCRIPTION
This PR addresses a bug with where the python wrapper searches for `libirbem.dll` or `libirbem.so` file. Before, if you installed the wrapper via

```shell
cd IRBEM/python
python3 -m pip install -e .
``` 
or 

```shell
cd IRBEM/python
python3 -m pip install .
```
pip creates a slightly different folder structure. This can raise an exception if other shared object files were found in `site-packages/`. This bug fix constrains the shared object search to `libirbem.dll` or `libirbem.so`, so that it ignores other shared objects in the same directory.