### PR TITLE
LAndI2Lstar shell splitting bug corrected

### DIFF
--- a/source/LAndI2Lstar.f
+++ b/source/LAndI2Lstar.f
@@ -20551,6 +20551,7 @@ c                     10: G3
 c
 c Declare internal variables
       INTEGER*4  option1,isat,IPA,ntime_tmp,sysaxesOUT,sysaxesIN
+      REAL*8     alti, lati, longi
       REAL*8     BLOCAL_tmp(ntime_max),BMIN_tmp(ntime_max)
       REAL*8     XJ_tmp(ntime_max),MLT_tmp(ntime_max)
       REAL*8     Lm_tmp(ntime_max),Lstar_tmp(ntime_max)
@@ -20586,6 +20587,9 @@ c Compute Bmin at all locations first.
            DO IPA=1,Nipa
               options(1)=0
               if (alpha(IPA).ne.90.0d0) then
+                 call get_coordinates ( sysaxes,
+     &        xIN1(isat), xIN2(isat), xIN3(isat),
+     &        alti, lati, longi, xIN )
                  CALL find_bm_nalpha(xIN,1,alpha(IPA),BL,
      &                BMIR,xGEO)
                  call make_lstar1(ntime_tmp,kext,options,sysaxesIN,


### PR DESCRIPTION
There was a bug in the LAndI2LStar_shell_splitting routine which prevented the computation for alphas not equal to 90 degrees. The mirror point was computed on an un-initialized variable `xIN`, which should have contained the GEO coordinates of the input point. 
I've added the missing call to `get_coordinates`, which fixes the routine.