### PR TITLE
Add a function to get IGRF version number.

### DIFF
--- a/docs/frames/category-menus.html
+++ b/docs/frames/category-menus.html
@@ -329,6 +329,8 @@ function init() {
         <br />
         <a href="frames.html#GET_IRBEM_NTIME_MAX" target="right">GET_IRBEM_NTIME_MAX</a>
         <br />
+        <a href="frames.html#GET_IGRF_VERSION" target="right">GET_IGRF_VERSION</a>
+        <br />
     </div>
     
     <div class="title" id="title3" style="TOP: 80px"><a style="COLOR: red" onclick="javascript: toggle(3,270); return false" href="#"><img id="pic3" src="closed.gif" border="0" name="pic3" />Magnetic

--- a/docs/frames/frames.html
+++ b/docs/frames/frames.html
@@ -5342,6 +5342,37 @@
     <font face="ARIAL, HELVETICA">call IRBEM_FORTRAN_RELEASE1(RLS)</font> 
     <p>
         <br />
+        <hr><a name="GET_IGRF_VERSION"></a> 
+    </p>
+    <h2><font face="ARIAL, HELVETICA"><font color="#0000ff">GET_IGRF_VERSION</font></font> 
+    </h2>
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">DESCRIPTION:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA">Returns the version number of the IGRF model.</font> 
+    <br />
+    &nbsp; 
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">INPUTS:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA"><b>NONE</b></font> 
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">OUTPUTS:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA"><b>IGRF_VERSION</b> IGRF version number (long integer).</font> 
+    <br />
+    &nbsp; 
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">CALLING SEQUENCE FROM MATLAB:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA">ntime_max = onera_desp_lib_igrf_version</font> 
+    <br />
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">CALLING SEQUENCE FROM IDL:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA">result = call_external(lib_name, 'igrf_version_idl_',igrf_version, /f_value)</font> 
+    <br />
+    <h3><font face="ARIAL, HELVETICA"><font color="#ff0000">CALLING SEQUENCE from FORTRAN:</font></font> 
+    </h3>
+    <font face="ARIAL, HELVETICA">call GET_IGRF_VERION_(igrf_version)</font> 
+    <br />
+    <p>
+        <br />
         <hr><a name="GET_IRBEM_NTIME_MAX"></a> 
     </p>
     <h2><font face="ARIAL, HELVETICA"><font color="#0000ff">GET_IRBEM_NTIME_MAX</font></font> 

--- a/matlab/libirbem.h
+++ b/matlab/libirbem.h
@@ -25,6 +25,7 @@ Paul O'Brien paul.obrien@aero.org
 
 void irbem_fortran_version1_(int *version);
 void get_irbem_ntime_max1_(int *ntime_max);
+void get_igrf_version_(int *igrf_version);
 
 void make_lstar1_(int *ntime, int *kext,
 		  int *options,int *sysaxes,

--- a/matlab/onera_desp_lib_igrf_version.m
+++ b/matlab/onera_desp_lib_igrf_version.m
@@ -1,0 +1,28 @@
+function igrf_version = onera_desp_lib_igrf_version()
+%***************************************************************************************************
+%
+% This file is part of IRBEM-LIB.
+%
+%    IRBEM-LIB is free software: you can redistribute it and/or modify
+%    it under the terms of the GNU Lesser General Public License as published by
+%    the Free Software Foundation, either version 3 of the License, or
+%    (at your option) any later version.
+%
+%    IRBEM-LIB is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU Lesser General Public License for more details.
+%
+%    You should have received a copy of the GNU Lesser General Public License
+%    along with IRBEM-LIB.  If not, see <http://www.gnu.org/licenses/>.
+%***************************************************************************************************
+%
+% igrf_version = onera_desp_lib_igrf_version()
+% size of ntime dimension in fortran arrays
+
+onera_desp_lib_load;
+
+nPtr = libpointer('int32Ptr',-1);
+calllib('onera_desp_lib','get_igrf_version_',nPtr);
+igrf_version = double(nPtr.value);
+

--- a/source/idl_wrappers.c
+++ b/source/idl_wrappers.c
@@ -72,6 +72,8 @@ IDL_SIMPLE(irbem_fortran_version,1)
 IDL_SIMPLE(irbem_fortran_release,1)
 IDL_SIMPLE(get_irbem_ntime_max,1)
 
+IDL_WRAPPER(igrf_version_idl,get_igrf_version,1)
+
 IDL_SIMPLE(make_lstar_shell_splitting,19)
 IDL_SIMPLE(lstar_phi,7)
 IDL_SIMPLE(drift_shell,17)

--- a/source/igrf_coef.f
+++ b/source/igrf_coef.f
@@ -19,6 +19,14 @@
 !
 ! VERSION: IGRF13
 !
+
+       subroutine get_igrf_version(version)
+          IMPLICIT NONE
+          INTEGER*4 version
+          version = 13
+       end
+
+
 ! [EOS TRANS. AGU APRIL 21, 1992, P. 182]
 !  Additional IGRF References:
 !  (J. GEOMAG. GEOELECTR.(1982), V.34, P.313-315,


### PR DESCRIPTION
The IGRF model, which is used as default inner magnetic field model in IRBEM, is periodically updated to cover more recent dates. This means that the IRBEM outputs can change after an update, if the IGRF model has been updated. To trace such changes in the model, one would need to access the IGRF version number used by the IRBEM library.

This PR adds a simple function to get the IGRF model version number. I've added the corresponding documentation, as well as the IDL and Matlab wrappers.