### PR TITLE
Matlab R2024b some "Analyze Code" fixes

### DIFF
--- a/matlab/onera_desp_lib_coord_trans.m
+++ b/matlab/onera_desp_lib_coord_trans.m
@@ -47,7 +47,7 @@ if c ~=3
     error('Argument X must be size n x 3 in %s',mfilename);
 end
 ntime = r;
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_empiricallstar.m
+++ b/matlab/onera_desp_lib_empiricallstar.m
@@ -43,7 +43,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 
@@ -62,7 +62,7 @@ if ntime>Nmax
             onera_desp_lib_empiricallstar(kext,options,matlabd(ii),maginput(ii,:),Lm(ii),J(ii));
     end
 else
-    [iyear,idoy,UT] = onera_desp_lib_matlabd2yds(matlabd);
+    [iyear,idoy,~] = onera_desp_lib_matlabd2yds(matlabd);
     LstarPtr = libpointer('doublePtr',Lstar);
     maginput = maginput';
     % expand arrays

--- a/matlab/onera_desp_lib_find_foot_point.m
+++ b/matlab/onera_desp_lib_find_foot_point.m
@@ -97,7 +97,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_find_magequator.m
+++ b/matlab/onera_desp_lib_find_magequator.m
@@ -76,7 +76,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_find_mirror_point.m
+++ b/matlab/onera_desp_lib_find_mirror_point.m
@@ -79,7 +79,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_fly_in_afrl_crres.m
+++ b/matlab/onera_desp_lib_fly_in_afrl_crres.m
@@ -84,7 +84,7 @@ else
     end
 end
 
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,length(x1));
 end
 
@@ -115,7 +115,7 @@ Nmax = onera_desp_lib_ntime_max; % maximum array size in fortran library
 Flux = nan(Nmax,1);
 if isempty(Ap15)
     Ap15 = nan(1,Nmax);
-elseif length(Ap15)==1
+elseif isscalar(Ap15)
     Ap15 = repmat(Ap15,1,Nmax);
 else
     Ap15 = [Ap15(:)', nan(1,Nmax-ntime)];

--- a/matlab/onera_desp_lib_fly_in_nasa_aeap.m
+++ b/matlab/onera_desp_lib_fly_in_nasa_aeap.m
@@ -55,7 +55,7 @@ else
     end
 end
 
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,length(x1));
 end
 

--- a/matlab/onera_desp_lib_get_bderivs.m
+++ b/matlab/onera_desp_lib_get_bderivs.m
@@ -93,7 +93,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 maginput = onera_desp_lib_maginputs(maginput); % NaN to baddata

--- a/matlab/onera_desp_lib_get_crres_flux.m
+++ b/matlab/onera_desp_lib_get_crres_flux.m
@@ -105,7 +105,7 @@ Nmax = onera_desp_lib_ntime_max; % maximum array size in fortran library
 Flux = nan(Nmax,1);
 if isempty(Ap15)
     Ap15 = nan(1,Nmax);
-elseif length(Ap15)==1
+elseif isscalar(Ap15)
     Ap15 = repmat(Ap15,1,Nmax);
 else
     Ap15 = [Ap15(:)', nan(1,Nmax-ntime)];

--- a/matlab/onera_desp_lib_get_field.m
+++ b/matlab/onera_desp_lib_get_field.m
@@ -76,7 +76,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_get_hemi.m
+++ b/matlab/onera_desp_lib_get_hemi.m
@@ -77,7 +77,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 maginput = onera_desp_lib_maginputs(maginput); % NaN to baddata

--- a/matlab/onera_desp_lib_get_mlt.m
+++ b/matlab/onera_desp_lib_get_mlt.m
@@ -34,7 +34,7 @@ end
 
 ntime = size(xGEO,1);
 
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 

--- a/matlab/onera_desp_lib_grid_lstar.m
+++ b/matlab/onera_desp_lib_grid_lstar.m
@@ -351,7 +351,7 @@ if ~isequal(settings,newsettings)
     grid.NLON = length(grid.lon);
     [grid.LAT,grid.LON] = meshgrid(grid.lat,grid.lon);
     grid.N = numel(grid.LAT);
-    [Bgeo,B] = onera_desp_lib_get_field(kext,options,'RLL',repmat(matlabd,grid.N,1),ones(grid.N,1),grid.LAT(:),grid.LON(:),repmat(maginput,grid.N,1));
+    [Bgeo,~] = onera_desp_lib_get_field(kext,options,'RLL',repmat(matlabd,grid.N,1),ones(grid.N,1),grid.LAT(:),grid.LON(:),repmat(maginput,grid.N,1));
     rhat = [cosd(grid.LAT(:)).*cosd(grid.LON(:)), cosd(grid.LAT(:)).*sind(grid.LON(:)), sind(grid.LAT(:))];
     Bdotr = reshape(sum(rhat.*Bgeo,2),size(grid.LAT));
     grid.partialPhi = cumtrapz(sind(grid.lat),Bdotr,2);
@@ -570,7 +570,7 @@ if true % dipole
     kext = '';
     maginput = [];
 else % T89, Kp=2
-    field_model = 'T89, Kp=2';
+    field_model = 'T89, Kp=2'; %#ok <UNRCH>
     options = {};
     kext = 'T89';
     maginput = onera_desp_lib_maginputs(2); % Kp=2
@@ -587,7 +587,7 @@ for ivar = 1:length(zvar)
             extras{end+1} = 'G'; % force Gauss in Bunit
             iplot = 1:length(z); % which z to plot
         case 'a0' % a0 grid
-            z = [2:2:90]; % deg
+            z = 2:2:90; % deg
             iplot = length(z):-2:1; % which z to plot
         case 'Bm' % Bmirror grid
             z = [0.3e3;1e3;3e3;10e3;30e3]; % nT

--- a/matlab/onera_desp_lib_load.m
+++ b/matlab/onera_desp_lib_load.m
@@ -1,4 +1,4 @@
-function info = onera_desp_lib_load(libfile,headerfile)
+function onera_desp_lib_load(libfile,headerfile)
 %***************************************************************************************************
 % Copyright 2009, T.P. O'Brien
 %

--- a/matlab/onera_desp_lib_lstar_phi.m
+++ b/matlab/onera_desp_lib_lstar_phi.m
@@ -44,11 +44,11 @@ matlabd = datenum(matlabd);
 
 onera_desp_lib_load;
 
-if (numel(matlabd)==1) && (numel(in)>1)
+if (isscalar(matlabd)) && (numel(in)>1)
     matlabd = repmat(matlabd,size(in));
 end
 
-if (numel(in)==1) && (numel(matlabd)>1)
+if (isscalar(in)) && (numel(matlabd)>1)
     in = repmat(in,size(matlabd));
 end
 

--- a/matlab/onera_desp_lib_maginputs.m
+++ b/matlab/onera_desp_lib_maginputs.m
@@ -50,7 +50,7 @@ function maginputs = onera_desp_lib_maginputs(varargin)
 % NaN's are replaced with the library bad data value, -1e31
 baddata=-1.0E31;
 
-if (length(varargin)==1) && (size(varargin{1},2)==25) % first/only arg is maginputs
+if (isscalar(varargin)) && (size(varargin{1},2)==25) % first/only arg is maginputs
     maginputs = varargin{1};
 else % multiple args
     n = max(arrayfun(@(x)length(x{1}),varargin)); % get length of longest list

--- a/matlab/onera_desp_lib_make_lstar_core.m
+++ b/matlab/onera_desp_lib_make_lstar_core.m
@@ -77,7 +77,7 @@ end
 if size(maginput,1) ~= ntime
     maginput = repmat(maginput,ntime,1);
 end
-if length(matlabd)==1
+if isscalar(matlabd)
     matlabd = repmat(matlabd,ntime,1);
 end
 maginput = onera_desp_lib_maginputs(maginput); % NaN to baddata

--- a/matlab/onera_desp_lib_msis.m
+++ b/matlab/onera_desp_lib_msis.m
@@ -101,7 +101,7 @@ else
 
     nanpad = nan(Nmax-N,1);
     date = [date(:);nanpad];
-    [iyear,idoy,UT] = onera_desp_lib_matlabd2yds(date);
+    [~,idoy,UT] = onera_desp_lib_matlabd2yds(date);
     Ap = [Ap;repmat(nanpad,1,size(Ap,2))];
     if WhichAp==1
         Ap = [Ap,nan(Nmax,6)]; % add extra columns

--- a/matlab/onera_desp_lib_multi_Lstar_hmin.m
+++ b/matlab/onera_desp_lib_multi_Lstar_hmin.m
@@ -41,7 +41,7 @@ end
 
 ntimes = numel(dates);
 
-if numel(alpha)==1
+if isscalar(alpha)
     alpha = repmat(alpha,ntimes,1);
 end
 

--- a/matlab/onera_desp_lib_sgp4_tle.m
+++ b/matlab/onera_desp_lib_sgp4_tle.m
@@ -92,7 +92,7 @@ if delOutFile
     % 6: longitude (deg)
     % 26/01/2007   0: 4:59.999982 2007.06850263      20096.506220        -0.002629      -124.124210
     % 26/01/2007   0:10: 0.000004 2007.06851218      20096.506204        -0.002508      -122.858292
-    [dd,mm,yyyy,hh,minute,ss,decyear,alt,lat,lon] = textread(OutFile,'%d/%d/%d %d:%d:%f %f %f %f %f');
+    [dd,mm,yyyy,hh,minute,ss,~,alt,lat,lon] = textread(OutFile,'%d/%d/%d %d:%d:%f %f %f %f %f');
 
     pos.date = datenum(yyyy,mm,dd,hh,minute,ss);
     pos.alt = alt;


### PR DESCRIPTION
Changes included are the following:

- "length(X)==1" and "numel(X)==1" changed to "isscalar(X)".
- Assigned but unused parameters replaced by "~".
- Silence a warning about unreachable test code (if true, X, else, Y; end).
- Remove output argument for function which never set this argument ('info' in onera_desp_lib_load.m).

The Matlab's `now` - is currently being discouraged, as per https://se.mathworks.com/help/matlab/ref/now.html, in favour of Matlab's `datetime`. This pull request does not apply any such changes as that could break backwards compatibility with older Matlab versions (before R2014b when `datetime` was introduced).

Feel free to edit this pull request directly, or comment with any potential improvements.