### PR TITLE
Fixing initialization issue in SUN subroutine

### DIFF
--- a/source/init_nouveau.f
+++ b/source/init_nouveau.f
@@ -899,6 +899,9 @@ C
         REAL*8     pi,rad
         common /rconst/rad,pi
 C
+
+       CALL INITIZE
+
       IF (iyr.LT.1901 .OR. iyr.GT.2099) RETURN
 C
       fday = secs/86400.D0


### PR DESCRIPTION
This PR closes #56.
The `SUN` subroutine uses the `pi` and `rad` variables, which should be initialized by calling `INITIZE`.
I assume that, in many cases, another function would have already called `INITIZE`, such as `RLL_GDZ`, `GDZ_GEO`, `GEO_GDZ`, etc.
However, when `GET_MLT1` is called on its own, the first call results in a failure.

I have also verified that this is the only missing `CALL INITIZE` in `init_nouveau.f`.