### PR TITLE
Changed bmin to bmirr variable name for find_mirror_point in python wrapper

### DIFF
--- a/python/IRBEM/IRBEM.py
+++ b/python/IRBEM/IRBEM.py
@@ -329,7 +329,7 @@ class MagFields:
         Returns
         -------
         dict
-            A dictionary with "blocal" and "bmin" scalars, and "POSIT" that contains the 
+            A dictionary with "blocal" and "bmirr" scalars, and "POSIT" that contains the 
             GEO coordinates of the mirror point.
         """
         a = ctypes.c_double(alpha)
@@ -338,7 +338,7 @@ class MagFields:
         self._prepMagInput(maginput)
         iyear, idoy, ut, x1, x2, x3 = self._prepTimeLoc(X)
         
-        blocal, bmin = [ctypes.c_double(-9999) for i in range(2)]
+        blocal, bmirr = [ctypes.c_double(-9999) for i in range(2)]
         positType = (3 * ctypes.c_double)
         posit = positType()
 
@@ -349,9 +349,9 @@ class MagFields:
                 ctypes.byref(iyear), ctypes.byref(idoy), ctypes.byref(ut), \
                 ctypes.byref(x1), ctypes.byref(x2), ctypes.byref(x3), \
                 ctypes.byref(a), ctypes.byref(self.maginput), \
-                ctypes.byref(blocal), ctypes.byref(bmin), ctypes.byref(posit))     
+                ctypes.byref(blocal), ctypes.byref(bmirr), ctypes.byref(posit))     
                 
-        self.find_mirror_point_output = {'blocal':blocal.value, 'bmin':bmin.value, \
+        self.find_mirror_point_output = {'blocal':blocal.value, 'bmirr':bmirr.value, \
                 'POSIT':posit[:]}
         return self.find_mirror_point_output
     

--- a/python/IRBEM/test_IRBEM.py
+++ b/python/IRBEM/test_IRBEM.py
@@ -141,7 +141,7 @@ class TestIRBEM(unittest.TestCase):
         """
         Test find_mirror_point for locally-mirroring electrons.
         """
-        find_mirror_point_true_dict = {'blocal': 42271.43059990003, 'bmin': 42271.43059990003,
+        find_mirror_point_true_dict = {'blocal': 42271.43059990003, 'bmirr': 42271.43059990003,
                                         'POSIT': [0.35282136776620165, 0.4204761325793738, 0.9448914452448274]}
         self.model.find_mirror_point(self.X, self.maginput, 90)
         self.assertAlmostEqualDict(self.model.find_mirror_point_output, 


### PR DESCRIPTION
This straight-forward PR contains the variable name change in the python wrapper's MagFields.find_miror_point() method. The name change is also updated in the test suite. This PR closes #54 , and is exactly the same as #55, but with the branch conflicts resolved.