### PR TITLE
Fix inconsistent L* values in make_lstar1 caused by persistent Ilflag state

### DIFF
--- a/source/calcul_Lstar_o.f
+++ b/source/calcul_Lstar_o.f
@@ -80,6 +80,7 @@ C
        common /rconst/rad,pi
 C
 C
+        Ilflag = 0
        Nder=Nder_def*r_resol
        Nreb=Nreb_def
        Ntet=Ntet_def*t_resol
@@ -286,14 +287,10 @@ C
         phi(I) = phi(I-1)+2.D0*pi/Nder
         Iflag_I = 0
 c	write(6,*)tet(I)
-	IF (Ilflag.EQ.0) THEN
          tetl = tet(I-1)
 	 IF (I.GT.2) tetl = 2.D0*tet(I-1)-tet(I-2)
          tet1 = tetl
-	ELSE
-	 tetl = tet(I)
-	 tet1 = tetl
-	ENDIF
+
 c	write(6,*)tetl
 c	read(5,*)
 	leI1 = baddata

--- a/source/onera_desp_lib.f
+++ b/source/onera_desp_lib.f
@@ -64,7 +64,7 @@ c declare inputs
 c
 c Declare internal variables
       INTEGER*4    isat,iyear,kint,ifail
-        INTEGER*4    t_resol,r_resol,Ilflag,Ilflag_old
+        INTEGER*4    t_resol,r_resol
       REAL*8     mlon,mlon1
       REAL*8     xGEO(3),xMAG(3),xSUN(3),rM,MLAT
       real*8     alti,lati,longi
@@ -75,12 +75,9 @@ c Declare output variables
         REAL*8     Lm(ntime_max),Lstar(ntime_max)
 C
       COMMON /magmod/k_ext,k_l,kint
-        COMMON /flag_L/Ilflag
         DATA  xSUN /1.d0,0.d0,0.d0/
       integer*4 int_field_select, ext_field_select
 C
-      Ilflag=0
-      Ilflag_old=Ilflag
       if (options(3).lt.0 .or. options(3).gt.9) options(3)=0
       t_resol=options(3)+1
       r_resol=options(4)+1
@@ -130,15 +127,8 @@ c        if (alti .le. 50.) ifail=-10 ! removed by TPO, 5/31/2011 - why would we
               GOTO 99
              endif
 c
-            Ilflag=0
            CALL calcul_Lstar_opt(t_resol,r_resol,XGeo
      &     ,Lm(isat),Lstar(isat),XJ(isat),BLOCAL(isat),BMIN(isat))
-c        if (Ilflag_old .eq.1 .and. Lstar(isat).eq. Baddata) then
-c         Ilflag=0
-c           CALL calcul_Lstar_opt(t_resol,r_resol,xGeo
-c  &        ,Lm(isat),Lstar(isat),XJ(isat),BLOCAL(isat),BMIN(isat))
-c      endif
-         Ilflag_old=Ilflag
 
 99         continue
 

--- a/source/onera_desp_lib.f
+++ b/source/onera_desp_lib.f
@@ -130,13 +130,14 @@ c        if (alti .le. 50.) ifail=-10 ! removed by TPO, 5/31/2011 - why would we
               GOTO 99
              endif
 c
+            Ilflag=0
            CALL calcul_Lstar_opt(t_resol,r_resol,XGeo
      &     ,Lm(isat),Lstar(isat),XJ(isat),BLOCAL(isat),BMIN(isat))
-           if (Ilflag_old .eq.1 .and. Lstar(isat).eq. Baddata) then
-            Ilflag=0
-              CALL calcul_Lstar_opt(t_resol,r_resol,xGeo
-     &        ,Lm(isat),Lstar(isat),XJ(isat),BLOCAL(isat),BMIN(isat))
-         endif
+c        if (Ilflag_old .eq.1 .and. Lstar(isat).eq. Baddata) then
+c         Ilflag=0
+c           CALL calcul_Lstar_opt(t_resol,r_resol,xGeo
+c  &        ,Lm(isat),Lstar(isat),XJ(isat),BLOCAL(isat),BMIN(isat))
+c      endif
          Ilflag_old=Ilflag
 
 99         continue


### PR DESCRIPTION
fixes #69 
fixes #41

**Summary**

This PR fixes a bug where calling `make_lstar1` with identical inputs returns inconsistent L* values.
The issue originates from the `COMMON /flag_L/ Ilflag` variable, which is used inside `calcul_Lstar_opt` to decide whether to reuse a predicted foot-point (when `Ilflag = 1`) or compute a new linear estimate (when `Ilflag = 0`).

**Previously:**

Ilflag was only initialized to `0` inside `make_lstar1`.
After the first successful L* computation, `Ilflag` became `1` and was not reset before subsequent calls.
This caused `calcul_Lstar_opt` to reuse the last theta value from previous calls, leading to inconsistent L* results for identical inputs.
This bug only affects make_lstar1: all other routines calling calcul_Lstar_opt do not rely on the returned value of `Ilflag`.

```
grep -rnw source/ -e "calcul_Lstar_opt"
source/calcul_Lstar_o.f:37:       call calcul_Lstar_opt(t_resol,r_resol,
source/calcul_Lstar_o.f:42:       SUBROUTINE calcul_Lstar_opt(t_resol,r_resol,
source/AE8_AP8.f:163:      CALL calcul_Lstar_opt(t_resol,r_resol,xGEO
source/onera_desp_lib.f:130:           CALL calcul_Lstar_opt(t_resol,r_resol,XGeo
source/onera_desp_lib.f:238:           CALL calcul_Lstar_opt(t_resol,r_resol,xGEO
source/onera_desp_lib.f:246:               CALL calcul_Lstar_opt(t_resol,r_resol,xGEOp(1,ipa)
source/onera_desp_lib.f:1761:           CALL calcul_Lstar_opt(t_resol,r_resol,xGeo
source/onera_desp_lib.f:1774:               CALL calcul_Lstar_opt(t_resol,r_resol,xGEOp(1,ipa)
source/AFRL_CRRES_models.f:143:           CALL calcul_Lstar_opt(t_resol,r_resol,xGEO
```

I have checked that the logic around these calls does not involves `Ilflag`. Moreoever, `make_lstar_shell_splitting1`, `make_lstar_shell_splitting2` already have a `Ilflag=0` line before each call.

**What this PR changes**
✔️ 1. Removed the handling of `Ilflag` from the caller (`make_lstar1`)

`make_lstar1` no longer uses `Ilflag`
The logic related to Ilflag_old and the fallback call has been removed.

✔️ 2. `Ilflag` is now always initialized to `0` inside `calcul_Lstar_opt`

This ensures deterministic behavior: each computation starts cleanly and does not reuse stale state.

✔️ 3. Removed the conditional branch based on `Ilflag`

**Outcome**

After this fix, calling `make_lstar1` multiple times with identical parameters now returns consistent L*, Lm, B, Beq, I, and MLT values.